### PR TITLE
Trivial convenience improvements

### DIFF
--- a/begateway/Classes/Flow/Entities/BGCard.swift
+++ b/begateway/Classes/Flow/Entities/BGCard.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-public struct BGCard: Codable {
+public struct BGCard: Codable, Equatable {
     public var number: String
     public var verificationValue: String
     public var holder: String

--- a/begateway/Classes/Flow/Entities/BGCheckoutResponse.swift
+++ b/begateway/Classes/Flow/Entities/BGCheckoutResponse.swift
@@ -7,23 +7,20 @@
 
 import Foundation
 
-struct BGCheckoutResponse: Codable {
-    var checkout: BGCheckoutResponseObject
-    
-    init(checkout: BGCheckoutResponseObject) {
-        self.checkout = checkout
-    }
+public struct BGCheckoutResponse: Codable {
+    public var checkout: BGCheckoutResponseObject
+
     enum CodingKeys: String, CodingKey {
         case checkout = "checkout"
     }
 }
 
 public struct BGCheckoutResponseObject: Codable {
-    var token: String
-    var redirectUrl: String?
-    var brands: [BGBrand]?
-    var company: BGCompany?
-    var description: String?
+    public var token: String
+    public var redirectUrl: String?
+    public var brands: [BGBrand]?
+    public var company: BGCompany?
+    public var description: String?
     
     enum CodingKeys: String, CodingKey {
         case token = "token"

--- a/begateway/Classes/Settings/BGCardType.swift
+++ b/begateway/Classes/Settings/BGCardType.swift
@@ -37,7 +37,7 @@ extension BGCardType: CaseIterable {
             return UIImage(named: "bgunknown", in: bundle, compatibleWith: nil)
         }
     }
-    var minCardLength: Int {
+    public var minCardLength: Int {
         switch self {
         case .MIR, .BELKART, .VISA, .MASTER, .DISCOVER:
             return 16
@@ -55,7 +55,7 @@ extension BGCardType: CaseIterable {
             return 12
         }
     }
-    var maxCardLength: Int {
+    public var maxCardLength: Int {
         switch self {
         case .MIR, .BELKART, .VISA, .MASTER, .DISCOVER:
             return 16
@@ -144,7 +144,7 @@ public enum BGCardType: String, Codable {
             return "^$"
         }
     }
-    init(cardNumber: String) {
+    public init(cardNumber: String) {
         for item in BGCardType.allCases {
             if let reg = try? NSRegularExpression(pattern: item.regex, options: .allowCommentsAndWhitespace) {
                 let nnn = reg.numberOfMatches(in: cardNumber, range: NSRange(cardNumber.startIndex..., in: cardNumber))
@@ -170,7 +170,7 @@ public enum BGCardType: String, Codable {
     internal static let AMEX_SPACE_INDICES = [4, 10]
     internal static let DEFAULT_SPACE_INDICES = [4, 8, 12]
     
-    func isLuhnValid(cardNumber: String) -> Bool {
+    public func isLuhnValid(cardNumber: String) -> Bool {
         if cardNumber.isEmpty { return false }
         let type = BGCardType(cardNumber: cardNumber)
         if !(type.minCardLength...type.maxCardLength ~= cardNumber.count) { return false }


### PR DESCRIPTION
These changes shouldn't break any app code, but improve convenience of SDK integration. 

Unnecessary privacy of these structs and properties causes code duplication.