### PR TITLE
Treat paymentResponse.url the same as threeDSecureVerification?.url

### DIFF
--- a/begateway/Classes/Flow/ServerWork/BGLoader.swift
+++ b/begateway/Classes/Flow/ServerWork/BGLoader.swift
@@ -81,7 +81,7 @@ class BGLoader {
                     case .error, .failed:
                         callback(.failure(paymentResponse.message ?? ""))
                     case .incomplete:
-                        guard let threeDSecURL = URL(string: paymentResponse.threeDSecureVerification?.url ?? "") else {
+                        guard let threeDSecURL = URL(string: paymentResponse.threeDSecureVerification?.url ?? paymentResponse.url ?? "") else {
                             callback(.incomplete)
                             return
                         }
@@ -133,7 +133,7 @@ class BGLoader {
                     case .error, .failed:
                         callback(.failure(paymentResponse.message ?? ""))
                     case .incomplete:
-                        guard let threeDSecURL = URL(string: paymentResponse.threeDSecureVerification?.url ?? "") else {
+                        guard let threeDSecURL = URL(string: paymentResponse.threeDSecureVerification?.url ?? paymentResponse.url ?? "") else {
                             callback(.incomplete)
                             return
                         }


### PR DESCRIPTION
I cannot guarantee this workaround is 100% safe for all apps integrating the SDK, 
but our integration requires this change for payments to succeed