### PR TITLE
Add ability to set ApplePay merchant name instead of a test string

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ After it you should pass merchant id to BegatewayOptions.
 Default <b>Apple Pay</b> with input:
 ```swift
         options.merchantID = "merchant.org.cocoapods.demo.begateway-Example"
-        
+        options.merchantName = "Your Company, OOO" // A name of the company that will appear on the customer's billing statement
+
         let _ = BeGateway.instance.setup(with: options)
         
         let request = BeGatewayRequest(amount: Double(self.valueTextField.text ?? "0.0") ?? 0.0,

--- a/begateway/Classes/BeGateway/BeGateway.swift
+++ b/begateway/Classes/BeGateway/BeGateway.swift
@@ -313,7 +313,7 @@ public class BeGateway {
         requestPK.merchantCapabilities = .capability3DS
         requestPK.countryCode = "BY"
         requestPK.currencyCode = currencyCode
-        requestPK.paymentSummaryItems = [PKPaymentSummaryItem(label: applePayConst.description, amount: NSDecimalNumber(string: amount))]
+        requestPK.paymentSummaryItems = [PKPaymentSummaryItem(label: self.options?.merchantName ?? applePayConst.description, amount: NSDecimalNumber(string: amount))]
         
         if self.delegatePK == nil {
             self.delegatePK = ApplePaymentModule(link: self)

--- a/begateway/Classes/BeGateway/BeGatewayOptions.swift
+++ b/begateway/Classes/BeGateway/BeGatewayOptions.swift
@@ -14,6 +14,7 @@ public class BeGatewayOptions {
     public var endpoint: String = "https://checkout.bepaid.by/ctp/api"
     var resultUrl: String = "https://127.default_return_url.com"
     public var merchantID : String?
+    public var merchantName: String?
     var notificationURL: String?
     
     var maxCheckingAttempts: Int = 30           // count of max attempts for checking status


### PR DESCRIPTION
Right now it uses a constant with "Apple Pay Test" text which prevents the app from being approved by Apple.
This pull requests adds `merchantName` property to `BeGatewayOptions` and uses `ApplePayConstants.description` as a fallback value.